### PR TITLE
Fix Volume Index Number when There is No Volume Number

### DIFF
--- a/ebook2kavita.py
+++ b/ebook2kavita.py
@@ -135,7 +135,7 @@ def set_epub_series_and_index(
             index += f"{volume_num}.{volume_part_num}"
         command += ["--index", index]
     else:
-        index = f"1.{folder_index}"
+        index = f"0.{folder_index + 1}"
         command += ["--index", index]
 
     while is_locked(target_epub_file_path):


### PR DESCRIPTION
The index needs to start at `1` instead of `0`, because in Kavita `1.0=1`. The default volume number was also changed to `0` so that it sorts before Volume 1